### PR TITLE
Test with instruction sequence caching

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
 gem 'get_process_mem'
+gem 'bootsnap'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,18 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    bootsnap (1.4.8)
+      msgpack (~> 1.0)
     ffi (1.13.1)
     get_process_mem (0.2.7)
       ffi (~> 1.0)
+    msgpack (1.3.3)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  bootsnap
   get_process_mem
 
 BUNDLED WITH

--- a/main-iseq.rb
+++ b/main-iseq.rb
@@ -1,0 +1,17 @@
+require 'bootsnap'
+Bootsnap.setup(cache_dir: '/tmp/bootsnap', compile_cache_iseq: true, load_path_cache: false, autoload_paths_cache: false)
+
+require 'get_process_mem'
+
+before = GetProcessMem.new.mb
+require_relative 'array_from_file.rb'
+after = GetProcessMem.new.mb
+
+puts "Memory difference (building an array from text file):     #{after - before} mb"
+
+before = GetProcessMem.new.mb
+require_relative 'huge_array_native.rb'
+after = GetProcessMem.new.mb
+
+puts "Memory difference (reading in a ruby array from source): #{after - before} mb"
+


### PR DESCRIPTION
Kevin Deisz shared this repo on our Slack channel, so I figured I take a look.

So, this is not to say there are no improvements that could be made, but if you enabled iseq caching (I did it using bootsnap for simplicity) the problem is pretty much gone:

cold cache:
```
$ bundle exec ruby main-iseq.rb
Memory difference (building an array from text file):     2.609375 mb
Memory difference (reading in a ruby array from source): 30.16796875 mb
```

second run:
```
$ bundle exec ruby main-iseq.rb
Memory difference (building an array from text file):     2.8984375 mb
Memory difference (reading in a ruby array from source): 2.38671875 mb
```

So that confirms that all these allocations come from the parser/lexer, but that's not really surprising though, as it uses a lot of Ruby objects rather than C structs.